### PR TITLE
Enable multiple credential validation.

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -1,6 +1,6 @@
 # koa-basic-auth [![Build Status](https://travis-ci.org/koajs/basic-auth.png)](https://travis-ci.org/koajs/basic-auth)
 
-  Add simple "blanket" basic auth with username / password. If you require
+  Add simple "blanket" basic auth with username / password or array of credential objects . If you require
   anything more specific just use the [basic-auth](https://github.com/visionmedia/node-basic-auth) module.
 
 ## Installation
@@ -69,6 +69,12 @@ var mount = require('koa-mount');
 var auth = require('koa-basic-auth');
 
 app.use(mount('/admin', auth({ name: 'tobi', pass: 'ferret' })));
+```
+## Multiple Credentials
+To use multiple credentials change the auth object to array.
+
+```js
+app.use(auth([{ name: 'tj', pass: 'tobi' }, { name: 'bb', pass: 'bob' }]));
 ```
 
 ## License

--- a/index.js
+++ b/index.js
@@ -7,6 +7,7 @@
 
 const auth = require('basic-auth');
 const assert = require('assert');
+const _ = require('lodash');
 
 /**
  * Return basic auth middleware with
@@ -23,13 +24,17 @@ const assert = require('assert');
 module.exports = function(opts){
   opts = opts || {};
 
-  assert(opts.name, 'basic auth .name required');
-  assert(opts.pass, 'basic auth .pass required');
+  if (_.isArray(opts) === false) {
+    assert(opts.name, 'basic auth .name required');
+    assert(opts.pass, 'basic auth .pass required');
+  }
 
   return function basicAuth(ctx, next){
     const user = auth(ctx);
-
-    if (user && user.name == opts.name && user.pass == opts.pass) {
+    
+    if (user && 
+       ((!_.isArray(opts) && user.name == opts.name && user.pass == opts.pass)
+       || (_.isArray(opts) && _.some(opts, {name: user.name, pass: user.pass}))) ) {
       return next();
     } else {
       ctx.throw(401);

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
   },
   "license": "MIT",
   "dependencies": {
-    "basic-auth": "^1.0.3"
+    "basic-auth": "^1.0.3",
+    "lodash": "^4.12.0"
   }
 }

--- a/test/test.js
+++ b/test/test.js
@@ -6,6 +6,14 @@ const assert = require('assert');
 const basicAuth = require('..');
 const Koa = require('koa');
 
+const validation = function(user) {
+  return new Promise((resolve, reject) => {
+    setTimeout(() => {
+      resolve(user && user.name === 'user' && user.pass === 'pass');
+    }, 300);
+  });  
+};
+
 describe('Koa Basic Auth', () => {
   describe('setup', () => {
     it('should throw an error when called with no name', () => {
@@ -50,14 +58,6 @@ describe('Koa Basic Auth', () => {
     it('should `throw` 401 validate throu async function', done => {
       const app = new Koa();
       
-      const validation = function(user) {
-        return new Promise((resolve, reject) => {
-          setTimeout(() => {
-            resolve(user && user.name === 'user' && user.pass === 'pass');
-          }, 300);
-        });  
-      };
-      
       app.use(basicAuth(validation));
 
       request(app.listen())
@@ -87,14 +87,6 @@ describe('Koa Basic Auth', () => {
     
     it('should call the next middleware with async validation function', done => {
       const app = new Koa();
-      
-      const validation = function(user) {
-        return new Promise((resolve, reject) => {
-          setTimeout(() => {
-            resolve(user && user.name === 'user' && user.pass === 'pass');
-          }, 300);
-        });  
-      };
 
       app.use(basicAuth(validation));
       app.use(ctx => {

--- a/test/test.js
+++ b/test/test.js
@@ -34,7 +34,7 @@ describe('Koa Basic Auth', () => {
     })
   })
 
-  describe('with invalid credentials', () => {
+  describe('with invalid credentials as object', () => {
     it('should `throw` 401', done => {
       const app = new Koa();
 
@@ -48,7 +48,7 @@ describe('Koa Basic Auth', () => {
     })
   })
 
-  describe('with valid credentials', () => {
+  describe('with valid credentials as object', () => {
     it('should call the next middleware', done => {
       const app = new Koa();
 
@@ -65,4 +65,37 @@ describe('Koa Basic Auth', () => {
       .end(done);
     })
   })
+  
+  describe('with invalid credentials as array', () => {
+    it('should `throw` 401', done => {
+      const app = new Koa();
+
+      app.use(basicAuth([{ name: 'user', pass: 'pass' }, { name: 'user_next', pass: 'pass_next' }]));
+
+      request(app.listen())
+      .get('/')
+      .auth('foo', 'bar')
+      .expect(401)
+      .end(done);
+    })
+  })
+
+  describe('with valid credentials as array', () => {
+    it('should call the next middleware', done => {
+      const app = new Koa();
+
+      app.use(basicAuth([{ name: 'user', pass: 'pass' }, { name: 'user_next', pass: 'pass_next' }]));
+      app.use(ctx => {
+        ctx.body = 'Protected';
+      })
+
+      request(app.listen())
+      .get('/')
+      .auth('user', 'pass')
+      .expect(200)
+      .expect('Protected')
+      .end(done);
+    })
+  })
+  
 })

--- a/testit.js
+++ b/testit.js
@@ -1,6 +1,0 @@
-
-const _ = require('lodash');
-
-let testArray = [{name: 'name1', pass: 'pass2'}, {name: 'name1', pass: 'pass1'}];
-
-console.log(_.some(testArray, {name: 'name2', pass: 'pass2'}));

--- a/testit.js
+++ b/testit.js
@@ -1,0 +1,6 @@
+
+const _ = require('lodash');
+
+let testArray = [{name: 'name1', pass: 'pass2'}, {name: 'name1', pass: 'pass1'}];
+
+console.log(_.some(testArray, {name: 'name2', pass: 'pass2'}));


### PR DESCRIPTION
I know that this should be a very simple implementation of basic-auth. But what speaks against it, instead of using a user name and password, a list? To receive or withdraw access get without having to change the password various user groups.